### PR TITLE
Quick job variables fix

### DIFF
--- a/functions/Set-ApiParameters.ps1
+++ b/functions/Set-ApiParameters.ps1
@@ -17,6 +17,13 @@ function Set-ApiParameters{
 	
 	Param(
 	[Parameter(Position = 0, Mandatory=$False)]
+	[ValidateSet(
+		"https://pinotage-api.centrastage.net",
+		"https://merlot-api.centrastage.net",
+		"https://concord-api.centrastage.net",
+		"https://zinfandel-api.centrastage.net",
+		"https://syrah-api.centrastage.net"
+	)]
 	$Url,
     
 	[Parameter(Position = 1, Mandatory=$False)]

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -17,10 +17,17 @@ function Set-DrmmDeviceQuickJob {
 	Provide name of the component to run.
 
 	.PARAMETER Variables 
-	Provide variables names and values, must be a hash.
+	Provide variables names and values, must be an array object (see examples)
+
+	.PARAMETER VariableDefinitions 
+	Provide variables names and values, must be an array object (see examples)
 
 	.EXAMPLE
+	$variables = @() + @{name = "variable1";value = "variable1Value"} + @{name="variable2";value='variable2Value'}
     $response = Set-DrmmDeviceQuickJob -DeviceUid '00000000-0000-0000-0000-000000000000' -jobName "Quick Job running Foo" -ComponentName "Foo" -Variables @{"bar"="baz";"qux"="quux"}
+	
+	.EXAMPLE
+	$response = Set-DrmmDeviceQuickJob -DeviceUid '00000000-0000-0000-0000-000000000000' -jobName "Quick Job running Foo" -ComponentName "Foo" -VariableDefinitions @{"variable1"="variable1Value";"variable2"="variable2Value"}
 	#>
 
 	# Function Parameters

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -19,6 +19,8 @@ function Set-DrmmDeviceQuickJob {
 	.PARAMETER Variables 
 	Provide variables names and values, must be a hash.
 
+	.EXAMPLE
+    $response = Set-DrmmDeviceQuickJob -DeviceUid '00000000-0000-0000-0000-000000000000' -jobName "Quick Job running Foo" -ComponentName "Foo" -Variables @{"bar"="baz";"qux"="quux"}
 	#>
 
 	# Function Parameters
@@ -33,7 +35,7 @@ function Set-DrmmDeviceQuickJob {
         $ComponentName,
 
         [Parameter(Mandatory=$False)] 
-        $variables
+        [hashtable]$variables
 
     )
 	
@@ -55,14 +57,24 @@ function Set-DrmmDeviceQuickJob {
 		throw "Could not find a component named `"$ComponentName`" specified by parameter 'ComponentName'"
 	}
 
+	#convert variable data from hashtable to array that can be converted to API-compatible JSON object
+    $variablesArray = @()
+    foreach ( $Key in $variables.Keys ) {
+        $temp = @{
+            "name" = $Key
+            "value" = $variables[$Key]
+        }
+        $variablesArray += $temp
+    }
+
 	# Create quick job request
 	$quickJobRequest.Add('jobName',$jobName)
 	$jobComponent.Add('componentUid',$componentUid)
-	$jobComponent.Add('variables',$variables)
+	$jobComponent.Add('variables',$variablesArray)
 	$quickJobRequest.Add('jobComponent',$jobComponent)
 
 	# Convert to JSON
-	$Body = $quickJobRequest | ConvertTo-Json
+	$Body = $quickJobRequest | ConvertTo-Json -Depth 3
 
 	# Update UDFs
 	return New-ApiRequest -apiMethod $apiMethod -apiRequest "/v2/device/$deviceUid/quickjob" -apiRequestBody $Body | ConvertFrom-Json

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -20,7 +20,7 @@ function Set-DrmmDeviceQuickJob {
 	Provide variables names and values, must be an array object (see examples)
 
 	.PARAMETER VariableDefinitions 
-	Provide variables names and values, must be an array object (see examples)
+	Provide variables names and values, must be a hashtable (see examples)
 
 	.EXAMPLE
 	$variables = @() + @{name = "variable1";value = "variable1Value"} + @{name="variable2";value='variable2Value'}

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -13,6 +13,9 @@ function Set-DrmmDeviceQuickJob {
 	.PARAMETER JobName
 	Provide name of the quick job.
 
+	.PARAMETER ComponentName
+	Provide name of the component to run.
+
 	.PARAMETER Variables 
 	Provide variables names and values, must be a hash.
 
@@ -24,7 +27,10 @@ function Set-DrmmDeviceQuickJob {
         $deviceUid,
 
         [Parameter(Mandatory=$True)] 
-        $jobName,
+		$jobName,
+		
+		[Parameter(Mandatory=$True)] 
+        $ComponentName,
 
         [Parameter(Mandatory=$False)] 
         $variables
@@ -35,15 +41,18 @@ function Set-DrmmDeviceQuickJob {
 	$apiMethod = 'PUT'
 	$jobComponent = @{}
 	$quickJobRequest = @{}
-	$componentUid = ''
 
 	# Get Component Uid
 	ForEach ($Component in Get-DrmmAccountComponents)
 	{
-		if($Component.name -eq $jobName)
+		if($Component.name -ieq $ComponentName)
 		{ 
 			$componentUid = $Component.uid
 		}
+	}
+
+	if ( $null -eq $componentUid ) {
+		throw "Could not find a component named `"$ComponentName`" specified by parameter 'ComponentName'"
 	}
 
 	# Create quick job request

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -24,18 +24,25 @@ function Set-DrmmDeviceQuickJob {
 	#>
 
 	# Function Parameters
+	[CmdletBinding(DefaultParameterSetName='preparedVariables')]
     Param (
-        [Parameter(Mandatory=$True)] 
+        [Parameter(Mandatory=$True,ParameterSetName = "preparedVariables")] 
+        [Parameter(Mandatory=$True,ParameterSetName = "unpreparedVariables")] 
         $deviceUid,
 
-        [Parameter(Mandatory=$True)] 
+        [Parameter(Mandatory=$True,ParameterSetName = "preparedVariables")] 
+        [Parameter(Mandatory=$True,ParameterSetName = "unpreparedVariables")] 
 		$jobName,
 		
-		[Parameter(Mandatory=$True)] 
+		[Parameter(Mandatory=$True,ParameterSetName = "preparedVariables")] 
+        [Parameter(Mandatory=$True,ParameterSetName = "unpreparedVariables")] 
         $ComponentName,
 
-        [Parameter(Mandatory=$False)] 
-        [hashtable]$variables
+        [Parameter(Mandatory=$False,ParameterSetName = "preparedVariables")] 
+		[PSCustomObject]$variables,
+		
+		[Parameter(Mandatory=$False,ParameterSetName = "unpreparedVariables")] 
+        [hashtable]$VariableDefinitions
 
     )
 	
@@ -57,20 +64,22 @@ function Set-DrmmDeviceQuickJob {
 		throw "Could not find a component named `"$ComponentName`" specified by parameter 'ComponentName'"
 	}
 
-	#convert variable data from hashtable to array that can be converted to API-compatible JSON object
-    $variablesArray = @()
-    foreach ( $Key in $variables.Keys ) {
-        $temp = @{
-            "name" = $Key
-            "value" = $variables[$Key]
-        }
-        $variablesArray += $temp
-    }
-
+	if ( $PSBoundParameters.ContainsKey('VariableDefinitions') ) {
+		#convert variable data from hashtable to array that can be converted to API-compatible JSON object
+		$variables = @()
+		foreach ( $Key in $VariableDefinitions.Keys ) {
+			$temp = @{
+				"name" = $Key
+				"value" = $VariableDefinitions[$Key]
+			}
+			$variables += $temp
+		}	
+	}
+	
 	# Create quick job request
 	$quickJobRequest.Add('jobName',$jobName)
 	$jobComponent.Add('componentUid',$componentUid)
-	$jobComponent.Add('variables',$variablesArray)
+	$jobComponent.Add('variables',$variables)
 	$quickJobRequest.Add('jobComponent',$jobComponent)
 
 	# Convert to JSON

--- a/functions/Set-DrmmDeviceQuickJob.ps1
+++ b/functions/Set-DrmmDeviceQuickJob.ps1
@@ -82,10 +82,10 @@ function Set-DrmmDeviceQuickJob {
 	$jobComponent.Add('variables',$variables)
 	$quickJobRequest.Add('jobComponent',$jobComponent)
 
-	# Convert to JSON
+	# Convert to JSON - Increased depth is needed to convert variable definitions if present
 	$Body = $quickJobRequest | ConvertTo-Json -Depth 3
 
-	# Update UDFs
+	# Create QuickKob
 	return New-ApiRequest -apiMethod $apiMethod -apiRequest "/v2/device/$deviceUid/quickjob" -apiRequestBody $Body | ConvertFrom-Json
 
 }


### PR DESCRIPTION
I was never able to get a hashtable that would properly set multiple variable values, so I added code to convert a simple hashtable, e.g. @{"bar"="baz";"qux"="quux"}, into an array that is compatible with Datto RMM API.

**This should be considered a breaking change**, as anyone who was calling this function with a variable hashtable in a successful way that I could not replicate would now need to alter their code.

I have tested this with zero, one, and two variables defined

There are a couple of other small changes that I made while working on this change that could be separated into a separate pull request if needed:

Set-ApiParameters
- Add validation set to facilitate user specifications

Set-DrmmDeviceQuickJob
- Separated out component name from job name so that a component may be specified by name and a different descriptive job name may be specified for the quick job.
- Made component name matching case insensitive
- Added error handling for the case where no component could be found