### PR TITLE
Add -UseBasicParsing parameter

### DIFF
--- a/functions/New-ApiAccessToken.ps1
+++ b/functions/New-ApiAccessToken.ps1
@@ -42,7 +42,7 @@ function New-ApiAccessToken {
 	# Request access token
 	try 
 	{
-		(Invoke-WebRequest @params | ConvertFrom-Json).access_token
+		(Invoke-WebRequest -UseBasicParsing @params | ConvertFrom-Json).access_token
 
 	}
 	catch 

--- a/functions/New-ApiRequest.ps1
+++ b/functions/New-ApiRequest.ps1
@@ -59,7 +59,7 @@ function New-ApiRequest {
 
 	# Make request
 	try {
-		(Invoke-WebRequest @params).Content
+		(Invoke-WebRequest -UseBasicParsing @params).Content
 	}
 	catch {
 		


### PR DESCRIPTION
Add -UseBasicParsing parameter to all instances of Invoke-WebRequest to eliminate request failures with the message "The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete."