### PR TITLE
fixed special character display. Invoke-Webrequest shows sometimes a …

### DIFF
--- a/functions/New-ApiRequest.ps1
+++ b/functions/New-ApiRequest.ps1
@@ -10,10 +10,10 @@ function New-ApiRequest {
 	.PARAMETER ApiMethod
 	Provide API Method GET, PUT or POST
 
-	.PARAMETER ApiRequest 
+	.PARAMETER ApiRequest
 	See Datto RMM API swagger UI
 
-	.PARAMETER ApiRequestBody 
+	.PARAMETER ApiRequestBody
 	Only used with PUT and POST request
 
     .INPUTS
@@ -25,7 +25,7 @@ function New-ApiRequest {
 	API response
 
 	#>
-    
+
 	Param(
 		[Parameter(Mandatory = $True)]
 		[ValidateSet('GET', 'PUT', 'POST', 'DELETE')]
@@ -33,7 +33,7 @@ function New-ApiRequest {
 
 		[Parameter(Mandatory = $True)]
 		[string]$apiRequest,
-    
+
 		[Parameter(Mandatory = $False)]
 		[string]$apiRequestBody
 	)
@@ -59,14 +59,15 @@ function New-ApiRequest {
 
 	# Make request
 	try {
-		(Invoke-WebRequest -UseBasicParsing @params).Content
+		$response = Invoke-WebRequest -UseBasicParsing @params
+		[System.Text.Encoding]::UTF8.GetString($response.RawContentStream.ToArray())
 	}
 	catch {
-		
+
 		$exceptionError = $_.Exception.Message
-		
+
 		switch ($exceptionError) {
-	
+
 			'The remote server returned an error: (429).' {
 				Write-Host 'New-ApiRequest : API rate limit breached, sleeping for 60 seconds'
 				Start-Sleep -Seconds 60


### PR DESCRIPTION


…weird behaviour with special characters. We reencode the RawContentStream basically with the same encoding as before.

# before fix
![dattoRMM-powershell-module-umlaut-error-description1-greyed](https://user-images.githubusercontent.com/89509741/130762686-6df8166b-3532-4e74-832d-9c50561f00a4.png)

# after fix
![dattoRMM-powershell-module-umlaut-error-fixed1-greyed](https://user-images.githubusercontent.com/89509741/130762726-e60aec90-3cb3-48c0-a4eb-4c3c62090b24.PNG)