### PR TITLE
Support setting True or False for onDemand Site flag

### DIFF
--- a/functions/Set-DrmmSite.ps1
+++ b/functions/Set-DrmmSite.ps1
@@ -40,7 +40,7 @@ function Set-DrmmSite {
         $siteNotes,
 
         [Parameter(Mandatory=$False)] 
-        [switch]$onDemand,
+        [bool]$onDemand,
 
         [Parameter(Mandatory=$False)] 
         [switch]$splashtopAutoInstall
@@ -54,7 +54,7 @@ function Set-DrmmSite {
 	$updateSiteRequest.Add('name',$siteName)
 	If ($PSBoundParameters.ContainsKey('siteDescription')) {$updateSiteRequest.Add('description',$siteDescription)}
 	If ($PSBoundParameters.ContainsKey('siteNotes')) {$updateSiteRequest.Add('notes',$siteNotes)}
-	If ($PSBoundParameters.ContainsKey('onDemand')) {$updateSiteRequest.Add('onDemand',$True)}
+	If ($PSBoundParameters.ContainsKey('onDemand')) {$updateSiteRequest.Add('onDemand',$onDemand)}
 	If ($PSBoundParameters.ContainsKey('splashtopAutoInstall')) {$updateSiteRequest.Add('splashtopAutoInstall',$True)}
 
 	# Convert to JSON


### PR DESCRIPTION
If a user wants to change an On-Demand site back to a Managed site, previously the DattoRMM cmdlets would not support this, and would always force onDemand to true.

This adds support to control the flag, passing True or False, allowing users to switch site types back and forth as desired.

This also can be handy in cases where a user has accidentally changed their default site from Managed to On-Demand and wants to switch it back.