### PR TITLE
pass unhandled error object to top of stack

### DIFF
--- a/functions/New-ApiRequest.ps1
+++ b/functions/New-ApiRequest.ps1
@@ -64,6 +64,7 @@ function New-ApiRequest {
 	}
 	catch {
 
+		$errorObject = $_
 		$exceptionError = $_.Exception.Message
 
 		switch ($exceptionError) {
@@ -88,7 +89,7 @@ function New-ApiRequest {
 			}
 
 			default {
-				Write-Host "$exceptionError"
+				Write-Error $errorObject
 			}
 
 		}


### PR DESCRIPTION
New-ApiRequest.ps1 is currently written such that a few errors that could be returned by the Datto RMM API (429, 403, 404, and 504) are handled, and all other errors are written to the console. This results in the output for those unhandled errors being lost when the function is used for automation purposes, and it makes error handling messier and more difficult. This change will pass the entire error object for unhandled errors to the top of the stack, so that the person using the DattoRMM module can use try/catch blocks to handle those errors independently.

An example use case for this is in the handling of 400 (Bad Request) errors, which the Datto RMM API can return when querying Site Variables for On Demand sites. Other errors returned by the API should be left to the DattoRMM module user to determine how to handle in their own automation.