### PR TITLE
PowerShell-Devices-Needing-Reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This module is designed to make it easier to use the Datto RMM API in your PowerShell scripts. As all the hard work is done,
+This module will make it easier to use the Datto RMM API in your PowerShell scripts. As all the hard work is done,
 you can develop your scripts faster and be more efficient. There is no need to go through a big learning curve spending lots
 of time working out how to use the Datto RMM API. Simply load the module, enter your API keys and get results within minutes!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This module will make it easier to use the Datto RMM API in your PowerShell scripts. As all the hard work is done,
+This module is designed to make it easier to use the Datto RMM API in your PowerShell scripts. As all the hard work is done,
 you can develop your scripts faster and be more efficient. There is no need to go through a big learning curve spending lots
 of time working out how to use the Datto RMM API. Simply load the module, enter your API keys and get results within minutes!
 

--- a/functions/Get-DevicesNeedingReboot.ps1
+++ b/functions/Get-DevicesNeedingReboot.ps1
@@ -1,0 +1,40 @@
+# Function to get devices needing reboot from all sites
+function Get-DevicesNeedingReboot {
+    # Iterate through all sites to get devices and filter those that need rebooting
+    $sites = Get-DrmmAccountSites
+
+    # Create an empty array to store devices needing reboot with converted timestamps
+    $devicesNeedingRebootList = @()
+
+    foreach ($site in $sites) {
+        $siteUid = $site.uid
+        $siteDevices = Get-DrmmSiteDevices -siteUid $siteUid
+
+        # Filter devices that need rebooting
+        $devicesNeedingReboot = $siteDevices | Where-Object { $_.RebootRequired -eq $true }
+
+        if ($devicesNeedingReboot.Count -gt 0) {
+            foreach ($device in $devicesNeedingReboot) {
+                # Convert Last Reboot Time and Last Seen from Unix timestamp to DateTime
+                $device | Add-Member -MemberType NoteProperty -Name "LastRebootDateTime" -Value ([System.DateTimeOffset]::FromUnixTimeMilliseconds($device.lastReboot).DateTime)
+                $device | Add-Member -MemberType NoteProperty -Name "LastSeenDateTime" -Value ([System.DateTimeOffset]::FromUnixTimeMilliseconds($device.lastSeen).DateTime)
+                $devicesNeedingRebootList += $device
+            }
+        }
+    }
+
+    # Sort the list by Last Reboot Time, oldest first
+    $sortedDevices = $devicesNeedingRebootList | Sort-Object -Property LastRebootDateTime
+
+    # Display the sorted list
+    foreach ($device in $sortedDevices) {
+        Write-Host "Hostname: $($device.hostname)"
+        Write-Host "Sitename: $($device.sitename)"
+        Write-Host "Description: $($device.description)"
+        Write-Host "Last Reboot Time: $($device.LastRebootDateTime)"
+        Write-Host "Last Seen: $($device.LastSeenDateTime)"
+        Write-Host "Online: $($device.Online)"
+        Write-Host "Portal URL: <a href='$($device.portalUrl)'>View on Web</a>"
+        Write-Host "----"
+    }
+}


### PR DESCRIPTION
This PowerShell script lets you fetch information about devices needing a reboot from multiple sites within a centralized management platform. It queries each site, identifies devices that require a reboot, and displays relevant details in an organized list. The script also converts Unix timestamps to human-readable date and time formats and provides clickable portal links for quick access to device information.