### PR TITLE
add support for new filter parameters in DRMM 13.4.0 release

### DIFF
--- a/functions/Get-DrmmAccountSites.ps1
+++ b/functions/Get-DrmmAccountSites.ps1
@@ -14,9 +14,10 @@ function Get-DrmmAccountSites {
 
     # Function Parameters
     Param (
-        
         [Parameter(Mandatory = $False)]
-        [Switch]$noDeletedDevices
+        [Switch]$noDeletedDevices,
+        [Parameter(Mandatory = $False)]
+        [string]$siteName
     )
 
     # Declare Variables
@@ -24,10 +25,21 @@ function Get-DrmmAccountSites {
     $maxPage = 250
     $nextPageUrl = $null
     $page = 0
+    $RequestUri = "/v2/account/sites?max=$maxPage&page=$page"
+
+	# Process query params
+	$queryParams = New-Object System.Collections.Generic.List[System.String]
+	if ($siteName) { $queryParams.Add("&siteName=$siteName") }
+
+	# Append the query parameters to the RequestUri
+    if ($queryParams.Count -gt 0) {
+        $RequestUri += [string]::Join('', $queryParams)
+    }
+
     $Results = @()
 
     $results = do {
-        $Response = New-ApiRequest -apiMethod $apiMethod -apiRequest "/v2/account/sites?max=$maxPage&page=$page" | ConvertFrom-Json
+        $Response = New-ApiRequest -apiMethod $apiMethod -apiRequest $RequestUri | ConvertFrom-Json
         if ($Response) {
             $nextPageUrl = $Response.pageDetails.nextPageUrl
             $Response.Sites


### PR DESCRIPTION
Datto RMM recently released [version 13.4.0](https://rmm.datto.com/help/en/Content/0HOME/ReleaseNotes/2024/ReleaseNotesDattoRMMv13.4.0.htm) in which they added new query parameters to the `/v2/account/devices` and `/v2/account/sites` endpoints. I added the parameters to their respective cmdlets.

**Get-DrmmAccountDevices:**

- hostname
- deviceType
- operatingSystem
- siteName

**Get-DrmmAccountSites:**

- siteName

Notably, the Datto RMM API uses a LIKE operator with these filters, so you don't have to enter in an exact name. Also, on `/v2/account/devices`, the API gives precedence to `filterId`, so I used a separate parameter set for that.