### PR TITLE
Adding Get-DRMMSiteDeviceNetworkInterfaces Cmdlet

### DIFF
--- a/functions/Get-DrmmSiteDeviceNetworkInterfaces.ps1
+++ b/functions/Get-DrmmSiteDeviceNetworkInterfaces.ps1
@@ -1,0 +1,49 @@
+function Get-DrmmSiteDeviceNetworkInterfaces {
+
+	<#
+	.SYNOPSIS
+	Fetches the devices records of the site identified by the given site uid.
+
+	.DESCRIPTION
+	Returns device settings, device type, device anti-virus status, device patch Status and UDF's.
+
+	.PARAMETER SiteUid
+	Provide site uid which will be use to return this site devices.
+	
+	.PARAMETER FilterId
+	Optional parameter specifying a filter to return only some devices 
+	#>
+    
+	# Function Parameters
+    Param (
+        [Parameter(Mandatory=$True)]
+		[String]$siteUid,
+		
+		[Parameter(Mandatory=$False)]
+        [String]$FilterId
+    )
+
+    # Declare Variables
+    $apiMethod = 'GET'
+    $maxPage = 250
+    $nextPageUrl = $null
+	$page = 0
+	if ( $PSBoundParameters.ContainsKey("FilterId") ) {
+		$filterQuery = "&filterId=$FilterId"
+	}
+	$Results = @()
+
+	$results =    do {
+	    $Response = New-ApiRequest -apiMethod $apiMethod -apiRequest "/v2/site/$siteUid/devices/network-interface?max=$maxPage&page=$page$filterQuery" | ConvertFrom-Json
+	    if ($Response) {
+		    $nextPageUrl = $Response.pageDetails.nextPageUrl
+		$Response.devices
+		    $page++
+	    }
+    }
+    until ($null -eq $nextPageUrl)
+
+    # Return all site devices
+    return $Results
+
+}

--- a/functions/Get-DrmmSiteDeviceNetworkInterfaces.ps1
+++ b/functions/Get-DrmmSiteDeviceNetworkInterfaces.ps1
@@ -2,10 +2,10 @@ function Get-DrmmSiteDeviceNetworkInterfaces {
 
 	<#
 	.SYNOPSIS
-	Fetches the devices records of the site identified by the given site uid.
+	Fetches the devices records with network interface information of the site identified by the given site uid.
 
 	.DESCRIPTION
-	Returns device settings, device type, device anti-virus status, device patch Status and UDF's.
+	Returns limited device information including network interface information for each device.
 
 	.PARAMETER SiteUid
 	Provide site uid which will be use to return this site devices.


### PR DESCRIPTION
In Datto RMM 13.6.0, network interface type is now being returned by default in requests to `/v2/audit/device/[deviceUid]`. We do not need to update code to take advantage of this.

A new API endpoint has been added, `/v2/site/[siteUid]/devices/network-interface`, which fetches shortened device records of a site, including network interface information in the `nics` property.

See here for full release notes: [https://rmm.datto.com/help/en/Content/0HOME/ReleaseNotes/2024/ReleaseNotesDattoRMMv13.6.0.htm](https://rmm.datto.com/help/en/Content/0HOME/ReleaseNotes/2024/ReleaseNotesDattoRMMv13.6.0.htm)